### PR TITLE
Trailing hit animation fix

### DIFF
--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -90,7 +90,7 @@ public class PlayerController : MonoBehaviour
         yield return null;
 
         animator.SetBool("attacking", false);
-        yield return new WaitForSeconds(0.3f);
+        yield return new WaitForSeconds(0.32f);
 
         currentState = PlayerState.idle;
 


### PR DESCRIPTION
Even though the animation is 0.21 seconds long , more time is needed due processes performed by Unity.  0.30 weren't enough and this is why the bug was appearing. I've tested and concluded that 0.32 is enough.